### PR TITLE
Introduce an initial travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: rust
+cache: cargo
 rust:
   - stable
   - beta

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: rust
 cache: cargo
-rust:
-  - stable
-  - beta
-  - nightly
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+
+matrix:
+  include:
+    - rust: stable
+      before_script:
+        - rustup component add rustfmt-preview
+      script:
+        - cargo fmt --all -- --write-mode=diff
+        - cargo test
+    - rust: beta
+      script:
+        - cargo test
+    - rust: nightly
+      before_script:
+        - rustup component add clippy-preview
+      script:
+        - cargo clippy
+        - cargo test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
       before_script:
         - rustup component add rustfmt-preview
       script:
-        - cargo fmt --all -- --write-mode=diff
+        - cargo fmt -- --check
         - cargo test
     - rust: beta
       script:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # BugHunt, Rust
 
+[![Build Status](https://travis-ci.org/blt/bughunt-rust.svg?branch=master)](https://travis-ci.org/blt/bughunt-rust)
+
 This project is aiming to provide "stateful" QuickCheck models for Rust's
 standard library. That is, we build up a random list of operations against an
 abstract data type, an "obviously correct" model of that ADT and apply the

--- a/src/stdlib/collections/hash_map.rs
+++ b/src/stdlib/collections/hash_map.rs
@@ -59,17 +59,17 @@ impl Hasher for TrulyAwfulHasher {
     }
 
     fn finish(&self) -> u64 {
-        self.hash_value as u64
+        u64::from(self.hash_value)
     }
 }
 
 /// A `HashMap<K, V>` model
 ///
 /// This type mimics the semantics of a `HashMap<K, V>` while being 'obviously
-/// correct' enough to serve as a QuickCheck model. The interface for the two
+/// correct' enough to serve as a `QuickCheck` model. The interface for the two
 /// types is roughly equivalent, except in construction. This similarity allows
 /// for `PropHashMap<K, V>` and `HashMap<K, V>` to be compared against one
-/// another in a QuickCheck suite.
+/// another in a `QuickCheck` suite.
 ///
 /// In actuality, `PropHashMap<K, V>` is a vector of `(K, V)`. The pairs are not
 /// held in order so the operations against the map are extremely


### PR DESCRIPTION
This commit introduces a basic Travis CI configuration into the
project. QC tests will just fly right on by but our clippy and
formatting warnings will be checked. The developer should still
run their models on their local machines for long periods.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>