### PR TITLE
Introduce more Ops for HashMap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: rust
 cache: cargo
 
+env:
+  global:
+    - QUICKCHECK_GENERATOR_SIZE=10000
+    - QUICKCHECK_TESTS=10000
+
 matrix:
   include:
     - rust: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,21 @@ matrix:
       script:
         - cargo fmt -- --check
         - cargo test
+    - rust: stable
+      script:
+        - cargo test --release
     - rust: beta
       script:
         - cargo test
+    - rust: beta
+      script:
+        - cargo test --release
     - rust: nightly
       before_script:
         - rustup component add clippy-preview
       script:
         - cargo clippy
         - cargo test
+    - rust: nightly
+      script:
+        - cargo test --release

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BugHunt, Rust
 
-[![Build Status](https://travis-ci.org/blt/bughunt-rust.svg?branch=master)](https://travis-ci.org/blt/bughunt-rust)
+[![Build Status](https://travis-ci.com/blt/bughunt-rust.svg?branch=master)](https://travis-ci.com/blt/bughunt-rust)
 
 This project is aiming to provide "stateful" QuickCheck models for Rust's
 standard library. That is, we build up a random list of operations against an


### PR DESCRIPTION
This commit introduces three new operations against HashMap:
ShrinkToFit, CheckCapacity and Clear. The consequences of these
operations are documented in the commit itself. I've also updated the
travis CI runner to run more tests of larger size by default. This
will need to be dialed backward as the number of models grow.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>