### PR TITLE
Use fuzzing to drive property testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+resources/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,10 @@ name = "bughunt-rust"
 version = "0.1.0-pre"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 
-[dev-dependencies]
-quickcheck = "0.6"
+[dependencies]
+afl = "0.4"
+arbitrary = "0.1"
+
+[[bin]]
+path = "src/bin/stdlib/collections/hash_map.rs"
+name = "hash_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 
 [dependencies]
 honggfuzz = "0.5"
-arbitrary = "0.1"
+arbitrary = { git = "https://github.com/blt/rust_arbitrary.git" }
 
 [[bin]]
 path = "src/bin/stdlib/collections/hash_map.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0-pre"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 
 [dependencies]
-afl = "0.4"
+honggfuzz = "0.5"
 arbitrary = "0.1"
 
 [[bin]]

--- a/src/bin/stdlib/collections/hash_map.rs
+++ b/src/bin/stdlib/collections/hash_map.rs
@@ -1,0 +1,98 @@
+#[macro_use]
+extern crate afl;
+extern crate arbitrary;
+extern crate bughunt_rust;
+
+use arbitrary::*;
+use bughunt_rust::stdlib::collections::hash_map::*;
+use std::collections::HashMap;
+
+fn main() {
+    loop {
+        fuzz!(|data: &[u8]| {
+            let mut ring = RingBuffer::new(data, 4048).unwrap();
+
+            let hash_seed: u8 = Arbitrary::arbitrary(&mut ring).unwrap();
+            let capacity: usize = Arbitrary::arbitrary(&mut ring).unwrap();
+            let total_ops: u16 = Arbitrary::arbitrary(&mut ring).unwrap();
+
+            let mut model: PropHashMap<u16, u16> = PropHashMap::new();
+            let mut sut: HashMap<u16, u16, BuildTrulyAwfulHasher> =
+                HashMap::with_capacity_and_hasher(capacity, BuildTrulyAwfulHasher::new(hash_seed));
+
+            for _ in 0..total_ops {
+                let op: Op<u16, u16> = Arbitrary::arbitrary(&mut ring).unwrap();
+                match op {
+                    Op::Clear => {
+                        // Clearning a HashMap removes all elements but keeps
+                        // the memory around for reuse. That is, the length
+                        // should drop to zero but the capacity will remain the
+                        // same.
+                        let prev_cap = sut.capacity();
+                        sut.clear();
+                        model.clear();
+                        assert_eq!(0, sut.len());
+                        assert_eq!(sut.len(), model.len());
+                        assert_eq!(prev_cap, sut.capacity());
+                    }
+                    Op::ShrinkToFit => {
+                        // NOTE There is no model behaviour here
+                        //
+                        // After a shrink the capacity may or may not shift from
+                        // the passed arg `capacity`. But, the capacity of the
+                        // HashMap should never grow after a shrink.
+                        //
+                        // Similarly, the length of the HashMap prior to a
+                        // shrink should match the length after a shrink.
+                        let prev_len = sut.len();
+                        let prev_cap = sut.capacity();
+                        sut.shrink_to_fit();
+                        assert_eq!(prev_len, sut.len());
+                        assert!(sut.capacity() <= prev_cap);
+                    }
+                    Op::Get { k } => {
+                        let model_res = model.get(&k);
+                        let sut_res = sut.get(&k);
+                        assert_eq!(model_res, sut_res);
+                    }
+                    Op::Insert { k, v } => {
+                        let model_res = model.insert(k, v);
+                        let sut_res = sut.insert(k, v);
+                        assert_eq!(model_res, sut_res);
+                    }
+                    Op::Remove { k } => {
+                        let model_res = model.remove(&k);
+                        let sut_res = sut.remove(&k);
+                        assert_eq!(model_res, sut_res);
+                    }
+                    Op::Reserve { n } => {
+                        // NOTE There is no model behaviour here
+                        //
+                        // When we reserve we carefully check that we're not
+                        // reserving into overflow territory. When
+                        // `#![feature(try_reserve)]` is available we can
+                        // make use of `try_reserve` on the SUT
+                        if sut.capacity().checked_add(n).is_some() {
+                            sut.reserve(n);
+                        } // else { assert!(sut.try_reserve(*n).is_err()); }
+                    }
+                }
+                // Check invariants
+                //
+                // `HashMap<K, V>` defines the return of `capacity` as
+                // being "the number of elements the map can hold
+                // without reallocating", noting that the number is a
+                // "lower bound". This implies that:
+                //
+                //  * the HashMap capacity must always be at least the
+                //    length of the model
+                assert!(sut.capacity() >= model.len());
+                // If the SUT is empty then the model must be.
+                assert_eq!(model.is_empty(), sut.is_empty());
+                // The length of the SUT must always be exactly the length of
+                // the model.
+                assert_eq!(model.len(), sut.len());
+            }
+        })
+    }
+}

--- a/src/bin/stdlib/collections/hash_map.rs
+++ b/src/bin/stdlib/collections/hash_map.rs
@@ -1,5 +1,5 @@
 #[macro_use]
-extern crate afl;
+extern crate honggfuzz;
 extern crate arbitrary;
 extern crate bughunt_rust;
 
@@ -10,88 +10,105 @@ use std::collections::HashMap;
 fn main() {
     loop {
         fuzz!(|data: &[u8]| {
-            let mut ring = RingBuffer::new(data, 4048).unwrap();
+            if let Ok(mut ring) = RingBuffer::new(data, 4048) {
+                let hash_seed: u8 =
+                    Arbitrary::arbitrary(&mut ring).expect("unable to compute hash_seed");
+                // Why is capacity not usize? We're very likely to request a
+                // capacity so large that the HashMap cannot allocate enough
+                // slots to store them, resulting in a panic when we call
+                // `with_capacity_and_hasher`. This is a crash, but an
+                // uninteresting one.
+                //
+                // We also request a low-ish capacity, all but guaranteeing we'll
+                // force reallocation during execution.
+                //
+                // See note on [`hash_map::Op::Reserve`] for details
+                let capacity: u8 =
+                    Arbitrary::arbitrary(&mut ring).expect("unable to compute capacity");
+                let total_ops: u16 =
+                    Arbitrary::arbitrary(&mut ring).expect("unable to compute total_ops");
 
-            let hash_seed: u8 = Arbitrary::arbitrary(&mut ring).unwrap();
-            let capacity: usize = Arbitrary::arbitrary(&mut ring).unwrap();
-            let total_ops: u16 = Arbitrary::arbitrary(&mut ring).unwrap();
+                let mut model: PropHashMap<u16, u16> = PropHashMap::new();
+                let mut sut: HashMap<u16, u16, BuildTrulyAwfulHasher> =
+                    HashMap::with_capacity_and_hasher(
+                        capacity as usize,
+                        BuildTrulyAwfulHasher::new(hash_seed),
+                    );
 
-            let mut model: PropHashMap<u16, u16> = PropHashMap::new();
-            let mut sut: HashMap<u16, u16, BuildTrulyAwfulHasher> =
-                HashMap::with_capacity_and_hasher(capacity, BuildTrulyAwfulHasher::new(hash_seed));
-
-            for _ in 0..total_ops {
-                let op: Op<u16, u16> = Arbitrary::arbitrary(&mut ring).unwrap();
-                match op {
-                    Op::Clear => {
-                        // Clearning a HashMap removes all elements but keeps
-                        // the memory around for reuse. That is, the length
-                        // should drop to zero but the capacity will remain the
-                        // same.
-                        let prev_cap = sut.capacity();
-                        sut.clear();
-                        model.clear();
-                        assert_eq!(0, sut.len());
-                        assert_eq!(sut.len(), model.len());
-                        assert_eq!(prev_cap, sut.capacity());
+                for _ in 0..total_ops {
+                    let op: Op<u16, u16> =
+                        Arbitrary::arbitrary(&mut ring).expect("unable to create Op");
+                    match op {
+                        Op::Clear => {
+                            // Clearning a HashMap removes all elements but keeps
+                            // the memory around for reuse. That is, the length
+                            // should drop to zero but the capacity will remain the
+                            // same.
+                            let prev_cap = sut.capacity();
+                            sut.clear();
+                            model.clear();
+                            assert_eq!(0, sut.len());
+                            assert_eq!(sut.len(), model.len());
+                            assert_eq!(prev_cap, sut.capacity());
+                        }
+                        Op::ShrinkToFit => {
+                            // NOTE There is no model behaviour here
+                            //
+                            // After a shrink the capacity may or may not shift from
+                            // the passed arg `capacity`. But, the capacity of the
+                            // HashMap should never grow after a shrink.
+                            //
+                            // Similarly, the length of the HashMap prior to a
+                            // shrink should match the length after a shrink.
+                            let prev_len = sut.len();
+                            let prev_cap = sut.capacity();
+                            sut.shrink_to_fit();
+                            assert_eq!(prev_len, sut.len());
+                            assert!(sut.capacity() <= prev_cap);
+                        }
+                        Op::Get { k } => {
+                            let model_res = model.get(&k);
+                            let sut_res = sut.get(&k);
+                            assert_eq!(model_res, sut_res);
+                        }
+                        Op::Insert { k, v } => {
+                            let model_res = model.insert(k, v);
+                            let sut_res = sut.insert(k, v);
+                            assert_eq!(model_res, sut_res);
+                        }
+                        Op::Remove { k } => {
+                            let model_res = model.remove(&k);
+                            let sut_res = sut.remove(&k);
+                            assert_eq!(model_res, sut_res);
+                        }
+                        Op::Reserve { n } => {
+                            // NOTE There is no model behaviour here
+                            //
+                            // When we reserve we carefully check that we're not
+                            // reserving into overflow territory. When
+                            // `#![feature(try_reserve)]` is available we can
+                            // make use of `try_reserve` on the SUT
+                            if sut.capacity().checked_add(n as usize).is_some() {
+                                sut.reserve(n as usize);
+                            } // else { assert!(sut.try_reserve(*n).is_err()); }
+                        }
                     }
-                    Op::ShrinkToFit => {
-                        // NOTE There is no model behaviour here
-                        //
-                        // After a shrink the capacity may or may not shift from
-                        // the passed arg `capacity`. But, the capacity of the
-                        // HashMap should never grow after a shrink.
-                        //
-                        // Similarly, the length of the HashMap prior to a
-                        // shrink should match the length after a shrink.
-                        let prev_len = sut.len();
-                        let prev_cap = sut.capacity();
-                        sut.shrink_to_fit();
-                        assert_eq!(prev_len, sut.len());
-                        assert!(sut.capacity() <= prev_cap);
-                    }
-                    Op::Get { k } => {
-                        let model_res = model.get(&k);
-                        let sut_res = sut.get(&k);
-                        assert_eq!(model_res, sut_res);
-                    }
-                    Op::Insert { k, v } => {
-                        let model_res = model.insert(k, v);
-                        let sut_res = sut.insert(k, v);
-                        assert_eq!(model_res, sut_res);
-                    }
-                    Op::Remove { k } => {
-                        let model_res = model.remove(&k);
-                        let sut_res = sut.remove(&k);
-                        assert_eq!(model_res, sut_res);
-                    }
-                    Op::Reserve { n } => {
-                        // NOTE There is no model behaviour here
-                        //
-                        // When we reserve we carefully check that we're not
-                        // reserving into overflow territory. When
-                        // `#![feature(try_reserve)]` is available we can
-                        // make use of `try_reserve` on the SUT
-                        if sut.capacity().checked_add(n).is_some() {
-                            sut.reserve(n);
-                        } // else { assert!(sut.try_reserve(*n).is_err()); }
-                    }
+                    // Check invariants
+                    //
+                    // `HashMap<K, V>` defines the return of `capacity` as
+                    // being "the number of elements the map can hold
+                    // without reallocating", noting that the number is a
+                    // "lower bound". This implies that:
+                    //
+                    //  * the HashMap capacity must always be at least the
+                    //    length of the model
+                    assert!(sut.capacity() >= model.len());
+                    // If the SUT is empty then the model must be.
+                    assert_eq!(model.is_empty(), sut.is_empty());
+                    // The length of the SUT must always be exactly the length of
+                    // the model.
+                    assert_eq!(model.len(), sut.len());
                 }
-                // Check invariants
-                //
-                // `HashMap<K, V>` defines the return of `capacity` as
-                // being "the number of elements the map can hold
-                // without reallocating", noting that the number is a
-                // "lower bound". This implies that:
-                //
-                //  * the HashMap capacity must always be at least the
-                //    length of the model
-                assert!(sut.capacity() >= model.len());
-                // If the SUT is empty then the model must be.
-                assert_eq!(model.is_empty(), sut.is_empty());
-                // The length of the SUT must always be exactly the length of
-                // the model.
-                assert_eq!(model.len(), sut.len());
             }
         })
     }

--- a/src/bin/stdlib/collections/hash_map.rs
+++ b/src/bin/stdlib/collections/hash_map.rs
@@ -39,12 +39,7 @@ fn main() {
                         BuildTrulyAwfulHasher::new(hash_seed),
                     );
 
-                loop {
-                    let op: Op<u16, u16> = if let Ok(op) = Arbitrary::arbitrary(&mut ring) {
-                        op
-                    } else {
-                        break;
-                    };
+                while let Ok(op) = Arbitrary::arbitrary(&mut ring) {
                     match op {
                         Op::Clear => {
                             // Clearning a HashMap removes all elements but keeps

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,4 @@
 extern crate arbitrary;
-#[cfg(test)]
-extern crate quickcheck;
-
 #[deny(warnings)]
 #[deny(bad_style)]
 #[deny(missing_docs)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+extern crate arbitrary;
 #[cfg(test)]
 extern crate quickcheck;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,15 +7,4 @@ extern crate arbitrary;
 #[deny(rust_2018_compatibility)]
 #[deny(rust_2018_idioms)]
 #[deny(unused)]
-#[cfg_attr(feature = "cargo-clippy", deny(clippy))]
-#[cfg_attr(feature = "cargo-clippy", deny(clippy_pedantic))]
-#[cfg_attr(feature = "cargo-clippy", deny(clippy_perf))]
-#[cfg_attr(feature = "cargo-clippy", deny(clippy_style))]
-#[cfg_attr(feature = "cargo-clippy", deny(clippy_complexity))]
-#[cfg_attr(feature = "cargo-clippy", deny(clippy_correctness))]
-#[cfg_attr(feature = "cargo-clippy", deny(clippy_cargo))]
-// We allow 'stuttering' as the structure of the project will mimic that of
-// stdlib. For instance, QC tests for HashMap will appear in a module called
-// `hash_map`.
-#[cfg_attr(feature = "cargo-clippy", allow(stutter))]
 pub mod stdlib;

--- a/src/stdlib/collections/hash_map.rs
+++ b/src/stdlib/collections/hash_map.rs
@@ -159,30 +159,36 @@ where
 /// step.
 #[derive(Clone, Debug)]
 pub enum Op<K, V> {
-    /// TODO
+    /// This opertion triggers `std::collections::HashMap::shrink_to_fit`
     ShrinkToFit,
-    /// TODO
+    /// This operation triggers `std::collections::HashMap::clear`
     Clear,
-    /// TODO
+    /// This operation triggers `std::collections::HashMap::reserve`
     Reserve {
-        /// TODO
-        n: usize,
+        /// Reserve `n` capacity elements
+        ///
+        /// Why is this not usize? It's possible we'll try to reserve
+        /// too much underlying capacity, forcing the `reserve` call to panic
+        /// when the underlying allocation fails. The HashMap does not document
+        /// its overhead per pair and `try_reserve` is still behind a feature
+        /// flag. So, we only reserve smallish capacity and hope for the best.
+        n: u16,
     },
-    /// TODO
+    /// This operation triggers `std::collections::HashMap::insert`
     Insert {
-        /// TODO
+        /// The key to be inserted
         k: K,
-        /// TODO
+        /// The value to be inserted
         v: V,
     },
-    /// TODO
+    /// This operation triggers `std::collections::HashMap::remove`
     Remove {
-        /// TODO
+        /// The key to be removed
         k: K,
     },
-    /// TODO
+    /// This operation triggers `std::collections::HashMap::get`
     Get {
-        /// TODO
+        /// The key to be removed
         k: K,
     },
 }
@@ -221,7 +227,7 @@ where
             3 => Op::ShrinkToFit,
             4 => Op::Clear,
             5 => {
-                let n: usize = Arbitrary::arbitrary(u)?;
+                let n: u16 = Arbitrary::arbitrary(u)?;
                 Op::Reserve { n }
             }
             _ => unreachable!(),

--- a/src/stdlib/collections/hash_map.rs
+++ b/src/stdlib/collections/hash_map.rs
@@ -1,4 +1,5 @@
 //! Tests for `std::collections::HashMap`
+use arbitrary::*;
 use std::hash::{BuildHasher, Hash, Hasher};
 use std::mem;
 
@@ -152,148 +153,79 @@ where
     }
 }
 
-#[cfg(test)]
-mod test {
-    use super::*;
-    use quickcheck::{Arbitrary, Gen, QuickCheck, TestResult};
-    use std::collections::HashMap;
+/// The `Op<K, V>` defines the set of operations that are available against
+/// `HashMap<K, V>` and `PropHashMap<K, V>`. Some map directly to functions
+/// available on the types, others require a more elaborate interpretation
+/// step.
+#[derive(Clone, Debug)]
+pub enum Op<K, V> {
+    /// TODO
+    ShrinkToFit,
+    /// TODO
+    Clear,
+    /// TODO
+    Reserve {
+        /// TODO
+        n: usize,
+    },
+    /// TODO
+    Insert {
+        /// TODO
+        k: K,
+        /// TODO
+        v: V,
+    },
+    /// TODO
+    Remove {
+        /// TODO
+        k: K,
+    },
+    /// TODO
+    Get {
+        /// TODO
+        k: K,
+    },
+}
 
-    // The `Op<K, V>` defines the set of operations that are available against
-    // `HashMap<K, V>` and `PropHashMap<K, V>`. Some map directly to functions
-    // available on the types, others require a more elaborate interpretation
-    // step. See `oprun` below for details.
-    #[derive(Clone, Debug)]
-    enum Op<K, V> {
-        ShrinkToFit,
-        Clear,
-        Reserve { n: usize },
-        Insert { k: K, v: V },
-        Remove { k: K },
-        Get { k: K },
-    }
-
-    impl<K: 'static, V: 'static> Arbitrary for Op<K, V>
+impl<K, V> Arbitrary for Op<K, V>
+where
+    K: Clone + Send + Arbitrary,
+    V: Clone + Send + Arbitrary,
+{
+    fn arbitrary<U>(u: &mut U) -> Result<Self, U::Error>
     where
-        K: Clone + Send + Arbitrary,
-        V: Clone + Send + Arbitrary,
+        U: Unstructured + ?Sized,
     {
-        fn arbitrary<G>(g: &mut G) -> Op<K, V>
-        where
-            G: Gen,
-        {
-            // ================ WARNING ================
-            //
-            // `total_enum_fields` is a goofy annoyance but it should match
-            // _exactly_ the number of fields available in `Op<K, V>`. If it
-            // does not then we'll fail to generate `Op` variants for use in our
-            // QC tests.
-            let total_enum_fields = 6;
-            let variant = g.gen_range(0, total_enum_fields);
-            match variant {
-                0 => {
-                    let k: K = Arbitrary::arbitrary(g);
-                    let v: V = Arbitrary::arbitrary(g);
-                    Op::Insert { k, v }
-                }
-                1 => {
-                    let k: K = Arbitrary::arbitrary(g);
-                    Op::Remove { k }
-                }
-                2 => {
-                    let k: K = Arbitrary::arbitrary(g);
-                    Op::Get { k }
-                }
-                3 => Op::ShrinkToFit,
-                4 => Op::Clear,
-                5 => {
-                    let n: usize = Arbitrary::arbitrary(g);
-                    Op::Reserve { n }
-                }
-                _ => unreachable!(),
+        // ================ WARNING ================
+        //
+        // `total_enum_fields` is a goofy annoyance but it should match
+        // _exactly_ the number of fields available in `Op<K, V>`. If it
+        // does not then we'll fail to generate `Op` variants for use in our
+        // QC tests.
+        let total_enum_fields = 6;
+        let variant: u8 = Arbitrary::arbitrary(u)?;
+        let op = match variant % total_enum_fields {
+            0 => {
+                let k: K = Arbitrary::arbitrary(u)?;
+                let v: V = Arbitrary::arbitrary(u)?;
+                Op::Insert { k, v }
             }
-        }
-    }
-
-    #[test]
-    fn oprun() {
-        fn inner(hash_seed: u8, capacity: usize, ops: Vec<Op<u16, u16>>) -> TestResult {
-            let mut model: PropHashMap<u16, u16> = PropHashMap::new();
-            let mut sut: HashMap<u16, u16, BuildTrulyAwfulHasher> =
-                HashMap::with_capacity_and_hasher(capacity, BuildTrulyAwfulHasher::new(hash_seed));
-            for op in &ops {
-                match op {
-                    Op::Clear => {
-                        // Clearning a HashMap removes all elements but keeps
-                        // the memory around for reuse. That is, the length
-                        // should drop to zero but the capacity will remain the
-                        // same.
-                        let prev_cap = sut.capacity();
-                        sut.clear();
-                        model.clear();
-                        assert_eq!(0, sut.len());
-                        assert_eq!(sut.len(), model.len());
-                        assert_eq!(prev_cap, sut.capacity());
-                    }
-                    Op::ShrinkToFit => {
-                        // NOTE There is no model behaviour here
-                        //
-                        // After a shrink the capacity may or may not shift from
-                        // the passed arg `capacity`. But, the capacity of the
-                        // HashMap should never grow after a shrink.
-                        //
-                        // Similarly, the length of the HashMap prior to a
-                        // shrink should match the length after a shrink.
-                        let prev_len = sut.len();
-                        let prev_cap = sut.capacity();
-                        sut.shrink_to_fit();
-                        assert_eq!(prev_len, sut.len());
-                        assert!(sut.capacity() <= prev_cap);
-                    }
-                    Op::Get { k } => {
-                        let model_res = model.get(k);
-                        let sut_res = sut.get(&k);
-                        assert_eq!(model_res, sut_res);
-                    }
-                    Op::Insert { k, v } => {
-                        let model_res = model.insert(*k, *v);
-                        let sut_res = sut.insert(*k, *v);
-                        assert_eq!(model_res, sut_res);
-                    }
-                    Op::Remove { k } => {
-                        let model_res = model.remove(k);
-                        let sut_res = sut.remove(k);
-                        assert_eq!(model_res, sut_res);
-                    }
-                    Op::Reserve { n } => {
-                        // NOTE There is no model behaviour here
-                        //
-                        // When we reserve we carefully check that we're not
-                        // reserving into overflow territory. When
-                        // `#![feature(try_reserve)]` is available we can
-                        // make use of `try_reserve` on the SUT
-                        if sut.capacity().checked_add(*n).is_some() {
-                            sut.reserve(*n);
-                        } // else { assert!(sut.try_reserve(*n).is_err()); }
-                    }
-                }
-                // Check invariants
-                //
-                // `HashMap<K, V>` defines the return of `capacity` as
-                // being "the number of elements the map can hold
-                // without reallocating", noting that the number is a
-                // "lower bound". This implies that:
-                //
-                //  * the HashMap capacity must always be at least the
-                //    length of the model
-                assert!(sut.capacity() >= model.len());
-                // If the SUT is empty then the model must be.
-                assert_eq!(model.is_empty(), sut.is_empty());
-                // The length of the SUT must always be exactly the length of
-                // the model.
-                assert_eq!(model.len(), sut.len());
+            1 => {
+                let k: K = Arbitrary::arbitrary(u)?;
+                Op::Remove { k }
             }
-            TestResult::passed()
-        }
-        QuickCheck::new().quickcheck(inner as fn(u8, usize, Vec<Op<u16, u16>>) -> TestResult)
+            2 => {
+                let k: K = Arbitrary::arbitrary(u)?;
+                Op::Get { k }
+            }
+            3 => Op::ShrinkToFit,
+            4 => Op::Clear,
+            5 => {
+                let n: usize = Arbitrary::arbitrary(u)?;
+                Op::Reserve { n }
+            }
+            _ => unreachable!(),
+        };
+        Ok(op)
     }
 }


### PR DESCRIPTION
This series of commits introduces the use of [arbitrary](https://crates.io/crates/arbitrary) and [honggfuzz-rs](https://github.com/rust-fuzz/honggfuzz-rs) in driving property tests, as discussed briefly by @Shnatsel and myself in #2. The code is now split between the library bits -- the `Op`, `Arbitrary` definition etc -- and the interpreter loop, now in the fuzz target called `hash_map`. If you have honggfuzz-rs installed you can run the fuzz target like:

    > cargo hfuzz run hash_map

Installation instructions for honggfuzz can be found at the above project link. 

In terms of finding bugs, this was effective at finding the panic crash resulting from @llogiq's introduction of `Op::Reserve`. The problem, as discussed in 9596448, is that we can make very large capacity requests of the HashMap and it will be unable to allocate memory to meet that request, causing a panic. HashMap does not publish its overhead per pair so we cannot determine if a reservation will fail ahead of time. The check we have in place mostly guards against this but fuzzing managed to turn up truly large reservation failures. It was neat. 

The downside to this approach is there's no tooling support for it: no shrinking, failure reports are given as the byte inputs. Dropping into a debugger works well enough but it's not the best. 