### PR TITLE
Update README to reflect AFL runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You can place these anywhere on disk you'd like. This is just an example. Okay,
 from the root of the project:
 
 ```
-> cargo build
+> cargo afl build
 > cargo afl fuzz -i /tmp/repeat/in -o /tmp/repeat/out/ target/debug/str_repeat
 ```
 

--- a/src/stdlib/collections/hash_map.rs
+++ b/src/stdlib/collections/hash_map.rs
@@ -166,7 +166,7 @@ pub enum Op<K, V> {
     /// This operation triggers `std::collections::HashMap::reserve`
     Reserve {
         /// Reserve `n` capacity elements
-        n: usize,
+        n: u16,
     },
     /// This operation triggers `std::collections::HashMap::insert`
     Insert {
@@ -221,7 +221,7 @@ where
             3 => Op::ShrinkToFit,
             4 => Op::Clear,
             5 => {
-                let n: usize = Arbitrary::arbitrary(u)?;
+                let n: u16 = Arbitrary::arbitrary(u)?;
                 Op::Reserve { n }
             }
             _ => unreachable!(),


### PR DESCRIPTION
This commit updates the README to reflect the changes made to use
model-based fuzzing, as opposed to straight QuickCheck. This resolves

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>